### PR TITLE
Add port to integration config

### DIFF
--- a/custom_components/ksenia_lares/__init__.py
+++ b/custom_components/ksenia_lares/__init__.py
@@ -59,3 +59,16 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Migrate old entry."""
+
+    if config_entry.version == 1:
+        new = {**config_entry.data}
+        new["port"] = 4202
+
+        config_entry.version = 2
+        hass.config_entries.async_update_entry(config_entry, data=new)
+
+    return True

--- a/custom_components/ksenia_lares/base.py
+++ b/custom_components/ksenia_lares/base.py
@@ -19,10 +19,11 @@ class LaresBase:
         username = data["username"]
         password = data["password"]
         host = data["host"]
+        port = data["port"]
 
         self._auth = aiohttp.BasicAuth(username, password)
         self._ip = host
-        self._port = 4202
+        self._port = port
         self._host = f"http://{host}:{self._port}"
         self._zone_descriptions = None
         self._partition_descriptions = None
@@ -112,7 +113,7 @@ class LaresBase:
 
         return self._partition_descriptions
 
-    async def paritions(self):
+    async def partitions(self):
         """Get status of partitions"""
         response = await self.get("partitions/partitionsStatus48IP.xml")
 

--- a/custom_components/ksenia_lares/config_flow.py
+++ b/custom_components/ksenia_lares/config_flow.py
@@ -31,6 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required("host"): str,
+        vol.Required("port", default=4202): int,
         vol.Required("username"): str,
         vol.Required("password"): str,
     }
@@ -56,7 +57,7 @@ async def validate_input(hass: HomeAssistant, data):
 class LaresConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Ksenia Lares Alarm."""
 
-    VERSION = 1
+    VERSION = 2
 
     @staticmethod
     @callback
@@ -94,7 +95,6 @@ class LaresConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
-
 
 class LaresOptionsFlowHandler(OptionsFlow):
     """Handle a options flow for Ksenia Lares Alarm."""

--- a/custom_components/ksenia_lares/coordinator.py
+++ b/custom_components/ksenia_lares/coordinator.py
@@ -30,6 +30,6 @@ class LaresDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch data from Ksenia Lares client."""
         async with async_timeout.timeout(DEFAULT_TIMEOUT):
             zones = await self.client.zones()
-            partitions = await self.client.paritions()
+            partitions = await self.client.partitions()
 
             return {DATA_ZONES: zones, DATA_PARTITIONS: partitions}

--- a/custom_components/ksenia_lares/strings.json
+++ b/custom_components/ksenia_lares/strings.json
@@ -4,6 +4,7 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
@@ -24,7 +25,7 @@
         "description": "Link different alarm states to partition and scenarios.",
         "data": {
           "scenario_disarm": "Disarm scenario",
-          "partition_away": "Away paritions",
+          "partition_away": "Away partitions",
           "scenario_away": "Away scenario",
           "partition_home": "Home partitions",
           "scenario_home": "Home scenario",

--- a/custom_components/ksenia_lares/translations/en.json
+++ b/custom_components/ksenia_lares/translations/en.json
@@ -12,6 +12,7 @@
             "user": {
                 "data": {
                     "host": "Host",
+                    "port": "Port",
                     "password": "Password",
                     "username": "Username"
                 }
@@ -24,7 +25,7 @@
                 "description": "Link partitions to states, the state will be set when the selected partitions are armed",
                 "data": {
                     "scenario_disarm": "Disarm scenario",
-                    "partition_away": "Away paritions",
+                    "partition_away": "Away partitions",
                     "scenario_away": "Away scenario",
                     "partition_home": "Home partitions",
                     "scenario_home": "Home scenario",


### PR DESCRIPTION
Hi there and thanks for this integration. 
I've been testing it on a Bticino 4200 which seems to be sharing the same http interface with Ksenia Lares. 
Only difference I've seen is that the Bticino exposes its http server on port 80 instead of the hardcoded 4202.
I think allowing for a custom port in the integration config can be useful to other people so I went ahead and drafted this PR. 
JFYI I've never worked with HA so please let me know if the changes make sense or should be done differently.